### PR TITLE
Untested solution for fixing build issue

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	dnsimple "github.com/dnsimple/dnsimple-go/dnsimple"
@@ -43,7 +42,7 @@ func main() {
 	var account string
 	var records []dnsimple.ZoneRecord
 	for _, a := range accounts.Data {
-		acc := strconv.Itoa(a.ID)
+		acc := string(a.ID)
 		zropts := &dnsimple.ZoneRecordListOptions{Name: recordname, Type: "TXT"}
 		recs, err := client.Zones.ListRecords(acc, zonename, zropts)
 		if err != nil {


### PR DESCRIPTION
Tried doing a build, got error:

```
+ go get -v github.com/lgierth/dnslink-dnsimple
github.com/lgierth/dnslink-dnsimple (download)
github.com/dnsimple/dnsimple-go (download)
github.com/google/go-querystring (download)
github.com/google/go-querystring/query
github.com/dnsimple/dnsimple-go/dnsimple
github.com/lgierth/dnslink-dnsimple
# github.com/lgierth/dnslink-dnsimple
src/github.com/lgierth/dnslink-dnsimple/main.go:46:24: cannot use a.ID (type int64) as type int in argument to strconv.Itoa
The command '/bin/sh -c set -ex &&   npm install -g aegir &&   go get -v github.com/lgierth/dnslink-dnsimple &&   go get -v github.com/davecheney/godoc2md' returned a non-zero code: 2
```

Tried this. It compiled. I have not tested it though.